### PR TITLE
Fix comments and expose new devshells

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # nix-config
 
 This repository contains a Nix flake that provides comprehensive configurations for all Linux and macOS machines I manage, alongside development shell environments. This flake ensures consistent system setups and development experiences across all machines running Nix.

--- a/devshells/kali-linux.nix
+++ b/devshells/kali-linux.nix
@@ -17,7 +17,6 @@ pkgs.mkShell {
     enum4linux    # Tool for enumerating information from Windows and Samba systems
     hydra         # Network logon cracker
     netcat        # Utility for reading from and writing to network connections
-    nikto         # Web server scanner (duplicate, can be removed)
     openvpn       # Open-source VPN software
     smbclient     # Samba client
     tcpdump       # Command-line packet analyzer

--- a/flake.nix
+++ b/flake.nix
@@ -253,7 +253,7 @@
         ];
       };
 
-      # Configuration for my M2 Macbook Air Delta (aarch64-darwin)
+      # Configuration for my M2 Macbook Air Juliet (aarch64-darwin)
       juliet = darwin.lib.darwinSystem {
         system = "aarch64-darwin";
         specialArgs = specialArgs // { hostname = "juliet"; dotfiles = dotfiles; };
@@ -309,7 +309,7 @@
 
 
     homeConfigurations = {
-      # Configuration for Respberry Pi RPi5
+      # Configuration for Raspberry Pi RPi5
       echo = home-manager.lib.homeManagerConfiguration {
         pkgs = import nixpkgs {
           system = "aarch64-linux";
@@ -347,6 +347,8 @@
         github-pages = import ./devshells/github-pages.nix { inherit pkgs; };
         kali-linux = import ./devshells/kali-linux.nix { inherit pkgs; };
         python-data-science = import ./devshells/python-data-science.nix { inherit pkgs; };
+        python-devops = import ./devshells/python-devops.nix { inherit pkgs; };
+        python-ytdlp = import ./devshells/python-ytdlp.nix { inherit pkgs; };
         typescript-devops = import ./devshells/typescript-devops.nix { inherit pkgs; };
       };
       aarch64-linux = let pkgs = import nixpkgs { system = "aarch64-linux"; }; in {
@@ -355,6 +357,8 @@
         github-pages = import ./devshells/github-pages.nix { inherit pkgs; };
         kali-linux = import ./devshells/kali-linux.nix { inherit pkgs; };
         python-data-science = import ./devshells/python-data-science.nix { inherit pkgs; };
+        python-devops = import ./devshells/python-devops.nix { inherit pkgs; };
+        python-ytdlp = import ./devshells/python-ytdlp.nix { inherit pkgs; };
         typescript-devops = import ./devshells/typescript-devops.nix { inherit pkgs; };
       };
       x86_64-darwin = let pkgs = import nixpkgs { system = "x86_64-darwin"; }; in {
@@ -363,6 +367,8 @@
         github-pages = import ./devshells/github-pages.nix { inherit pkgs; };
         kali-linux = import ./devshells/kali-linux.nix { inherit pkgs; };
         python-data-science = import ./devshells/python-data-science.nix { inherit pkgs; };
+        python-devops = import ./devshells/python-devops.nix { inherit pkgs; };
+        python-ytdlp = import ./devshells/python-ytdlp.nix { inherit pkgs; };
         typescript-devops = import ./devshells/typescript-devops.nix { inherit pkgs; };
       };
       x86_64-linux = let pkgs = import nixpkgs { system = "x86_64-linux"; }; in {
@@ -371,6 +377,8 @@
         github-pages = import ./devshells/github-pages.nix { inherit pkgs; };
         kali-linux = import ./devshells/kali-linux.nix { inherit pkgs; };
         python-data-science = import ./devshells/python-data-science.nix { inherit pkgs; };
+        python-devops = import ./devshells/python-devops.nix { inherit pkgs; };
+        python-ytdlp = import ./devshells/python-ytdlp.nix { inherit pkgs; };
         typescript-devops = import ./devshells/typescript-devops.nix { inherit pkgs; };
       };
     };


### PR DESCRIPTION
## Summary
- fix Raspberry Pi comment
- clarify juliet host comment
- remove duplicate `nikto` package
- expose `python-devops` and `python-ytdlp` devshells
- drop blank line at start of README

## Testing
- `nix fmt` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438996a9008328bab6cebafc614776