### PR TITLE
Fix xrdp window manager for XFCE

### DIFF
--- a/modules/nixos/xfce4.nix
+++ b/modules/nixos/xfce4.nix
@@ -28,7 +28,7 @@
 
   # RDP
   services.xrdp.enable = true;
-  services.xrdp.defaultWindowManager = "xfce+i3";
+  services.xrdp.defaultWindowManager = "startxfce4";
   services.xrdp.openFirewall = true;
 
   # Enable network manager applet


### PR DESCRIPTION
## Summary
- update xrdp defaultWindowManager for the XFCE module

## Testing
- `nix fmt` *(fails: `nix` not found)*
- `pre-commit run --files modules/nixos/xfce4.nix` *(fails: `pre-commit` not found)*
- `nixos-rebuild switch` *(fails: `nixos-rebuild` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1056c7448328a71a28532994bc53