### PR TITLE
Update i3 config to use dotfiles

### DIFF
--- a/modules/home/i3.nix
+++ b/modules/home/i3.nix
@@ -5,41 +5,10 @@
   xsession.enable = true;
   xsession.windowManager.i3 = {
     enable = true;
-    config = {
-      modifier = "Mod4"; # Windows key
-      fonts = {
-        names = [ "JetBrainsMono Nerd Font" ];
-        size = 12.0;
-      };
-
-      keybindings = {
-        "Mod4+Return" = "exec alacritty";
-        "Mod4+d" = "exec rofi -show run";
-        "Mod4+Shift+q" = "kill";
-        "Mod4+Shift+r" = "restart";
-        # CHANGE LAYOUTS:
-        "Mod4+s" = "layout stacking";  # set stacking layout
-        "Mod4+w" = "layout tabbed";    # set tabbed layout
-        "Mod4+e" = "layout toggle split"; # toggle between vertical/horizontal split
-
-        # MOVE FOCUS AROUND (optional but nice)
-        "Mod4+h" = "focus left";
-        "Mod4+j" = "focus down";
-        "Mod4+k" = "focus up";
-        "Mod4+l" = "focus right";
-      };
-
-      bars = [
-        {
-          statusCommand = "i3status";
-          fonts = {
-            names = [ "JetBrainsMono Nerd Font" ];
-            size = 12.0;
-          };
-        }
-      ];
-    };
   };
+
+  # Use configuration from the dotfiles repository
+  xdg.configFile."i3/config".source = lib.mkForce "${dotfiles}/i3/config";
 
   home.packages = with pkgs; [
     i3


### PR DESCRIPTION
## Summary
- use config from user's dotfiles for i3 window manager
- force override of the default i3 config path

## Testing
- `apt-get update && apt-get install -y nix`
- `nix --extra-experimental-features 'nix-command flakes' flake check` *(fails to complete due to long build; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_684b9b3032448328bb97f555f20d2e33