### PR TITLE
Add setup script for Nix tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS Instructions
+
+This repository contains Nix configurations and development environments.
+
+## Formatting and Style
+
+- Indent all Nix files using **two spaces**. Avoid tabs.
+- Ensure every file ends with a trailing newline.
+- Run `nix fmt` before committing to format Nix sources.
+
+## Programmatic Checks
+
+Before submitting a change, run the following commands:
+
+1. `nix fmt` – formats all Nix files.
+2. `nix flake check` – verifies the flake evaluates correctly.
+
+If these commands fail due to missing dependencies or network restrictions,
+use `scripts/setup_testing_tools.sh` to install the necessary tools. Note this in the PR under the **Testing** section.
+
+## Commit Guidelines
+
+- Make small, focused commits with clear messages describing the change.
+- Do not amend or rebase existing commits in the pull request.
+
+## Pull Request Guidelines
+
+Include a summary of your changes referencing file paths and line numbers
+where appropriate. Provide a **Testing** section describing which commands
+were run and their results.
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,3 +7,4 @@ Various helper scripts used with this repository.
 - **cmatrix_screensaver.sh** - Simple matrix screensaver script.
 - **tmux_startup.sh** - Sample script for starting predefined tmux sessions.
 - **darwin_set_proxy.py** - Helper for configuring a proxy on macOS builds.
+- **setup_testing_tools.sh** - Install Nix and enable flakes for running `nix fmt` and `nix flake check`.

--- a/scripts/setup_testing_tools.sh
+++ b/scripts/setup_testing_tools.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Setup the Nix environment so `nix fmt` and `nix flake check` can run.
+# This installs Nix in single-user mode and enables flakes.
+set -e
+
+# Install Nix if not already installed
+if ! command -v nix >/dev/null 2>&1; then
+  echo "Installing Nix..."
+  sh <(curl -L https://nixos.org/nix/install) --no-daemon
+  . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+else
+  echo "Nix already installed"
+fi
+
+# Ensure flakes are enabled
+mkdir -p "$HOME/.config/nix"
+if ! grep -q "experimental-features" "$HOME/.config/nix/nix.conf" 2>/dev/null; then
+  echo "experimental-features = nix-command flakes" >> "$HOME/.config/nix/nix.conf"
+fi
+
+# Install alejandra for nix fmt
+nix profile install --inputs-from . nixpkgs#alejandra
+
+echo "Nix environment setup complete."


### PR DESCRIPTION
## Summary
- document how to fix missing Nix tools
- add `scripts/setup_testing_tools.sh` for installing Nix and enabling flakes
- list setup script in `scripts/README.md`

## Testing
- `nix fmt` *(fails: command not found)*
- `nix flake check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685612307dd0832886685b07a7e8979c