### PR TITLE
Update Mac model identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,18 @@ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 
 - **alpha**: NixOS 24.11 (Vicuna) on Intel Core i5-3570K with NVIDIA GeForce GTX 660.
 - **bravo**: NixOS 24.11 (Vicuna) with i3 on AMD Ryzen 9 3900X and NVIDIA GeForce RTX 3070.
-- **charlie**: 2017 Intel 13-inch MacBook Pro.
-- **delta**: macOS Sequoia 15.4 on 2022 M2 13-inch MacBook Air.
+- **charlie**: 2017 Intel 13-inch MacBook Pro (two Thunderbolt 3 ports, **MacBookPro14,1**).
+- **delta**: macOS Sequoia 15.4 on 2022 M2 13-inch MacBook Air (**Mac14,2**).
 - **echo**: Raspberry Pi 5.
-- **foxtrot**: Early 2013 13-inch Retina MacBook Pro.
-- **golf**: Late-2011 15-inch MacBook Pro.
+- **foxtrot**: Early 2013 13-inch Retina MacBook Pro (**MacBookPro10,2**).
+- **golf**: Late-2011 15-inch MacBook Pro (**MacBookPro8,2**).
 - **hotel**: Digital Ocean droplet originally running Ubuntu.
 - **india**: Steam Deck running SteamOS with home-manager.
-- **juliet**: macOS Sequoia 15.3.2 on 2024 M4 Mac Mini.
+- **juliet**: macOS Sequoia 15.3.2 on 2024 base M4 Mac Mini (**Mac16,10**).
 - **kilo**: Ubuntu 24.04.2 LTS on Beelink EQR5 with AMD Ryzen 7 5825U.
 - **lima**: Beelink EQR5 worker node.
 - **mike**: Beelink EQR5 worker node.
-- **november**: Mac Mini A1347.
+- **november**: Mac Mini A1347 (Late 2014, **Macmini7,1**).
 
 ## Other Configurations
 - **digitalocean**: Uses nixos-anywhere to install NixOS on a Linux droplet

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
         ];
       };
 
-      # Configuration for NixOS Desktop Charlie (x86_64-linux)
+      # Configuration for NixOS on MacBookPro14,1 Charlie (x86_64-linux)
       charlie = nixpkgs-unstable.lib.nixosSystem {
         system = "x86_64-linux";
         modules = [
@@ -191,7 +191,7 @@
     };
 
     darwinConfigurations = {
-      # Configuration for 2017 13-inch MacBook Pro Charlie (x86_64-darwin)
+      # Configuration for 2017 13-inch MacBook Pro (two Thunderbolt 3 ports, MacBookPro14,1) Charlie (x86_64-darwin)
       charlie = darwin.lib.darwinSystem {
         system = "x86_64-darwin";
         specialArgs = specialArgs // { hostname = "charlie"; dotfiles = dotfiles; };
@@ -208,7 +208,7 @@
         ];
       };
 
-      # Configuration for my M2 Macbook Air Delta (aarch64-darwin)
+      # Configuration for 2022 M2 MacBook Air (Mac14,2) Delta (aarch64-darwin)
       delta = darwin.lib.darwinSystem {
         system = "aarch64-darwin";
         specialArgs = specialArgs // { hostname = "delta"; dotfiles = dotfiles; };
@@ -241,7 +241,7 @@
         ];
       };
 
-      # Configuration for my M2 Macbook Air Juliet (aarch64-darwin)
+      # Configuration for 2024 base M4 Mac mini (Mac16,10) Juliet (aarch64-darwin)
       juliet = darwin.lib.darwinSystem {
         system = "aarch64-darwin";
         specialArgs = specialArgs // { hostname = "juliet"; dotfiles = dotfiles; };
@@ -277,7 +277,7 @@
         ];
       };
 
-      # Configuration for MacBook Pro (Retina, 13-inch, Early 2013) Foxtrot (x86_64-darwin)
+      # Configuration for MacBook Pro (Retina, 13-inch, Early 2013, MacBookPro10,2) Foxtrot (x86_64-darwin)
       foxtrot = darwin.lib.darwinSystem {
         system = "x86_64-darwin";
         specialArgs = specialArgs // { hostname = "foxtrot"; dotfiles = dotfiles; };

--- a/hosts/charlie/README.md
+++ b/hosts/charlie/README.md
@@ -1,3 +1,3 @@
 # Charlie
 
-2017 Intel 13" MacBook Pro running macOS Ventura 13.6.9. Build with `just darwin-charlie`.
+2017 Intel 13" MacBook Pro (two Thunderbolt 3 ports, **MacBookPro14,1**) running macOS Ventura 13.6.9. Build with `just darwin-charlie`.

--- a/hosts/golf/README.md
+++ b/hosts/golf/README.md
@@ -1,3 +1,3 @@
 # Golf
 
-Late-2011 15" MacBook Pro running NixOS 24.05. Apply with `just nixos-golf`.
+Late-2011 15" MacBook Pro (**MacBookPro8,2**) running NixOS 24.05. Apply with `just nixos-golf`.


### PR DESCRIPTION
## Summary
- document model identifiers for managed Macs
- note MacBookPro14,1 in Charlie docs
- note MacBookPro8,2 in Golf docs
- clarify Mac host model references in flake

## Testing
- `scripts/setup_testing_tools.sh` *(fails: installing Nix as root is not supported)*
- `nix fmt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576fd3013883288e7096b478bcd744