### PR TITLE
Add KDE Plasma support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ To update configurations on any host, utilize the provided Justfile to run the n
   - `hyprland`: NixOS Hyprland configuration.
   - `nvidia-legacy_470`: Legacy NVIDIA driver for GeForce GTX.
   - `nvidia-stable`: Stable NVIDIA driver for GeForce RTX.
+  - `plasma`: KDE Plasma desktop environment.
   - `xfce4`: Xfce desktop environment.
 - **stylix**: Stylix configuration.
 

--- a/modules/nixos/plasma.nix
+++ b/modules/nixos/plasma.nix
@@ -1,0 +1,24 @@
+{ config, pkgs, ... }:
+
+{
+  services.xserver = {
+    enable = true;
+    desktopManager.plasma6.enable = true;
+    displayManager.sddm.enable = true;
+    xkb.layout = "us";
+    xkb.variant = "";
+  };
+
+  services.displayManager.defaultSession = "plasma";
+
+  # Optional: common packages for KDE
+  users.users.budchris = {
+    packages = with pkgs; [
+      kdePackages.kdeplasma-addons
+      pavucontrol
+      pasystray
+      gnome-keyring
+      pinentry-all
+    ];
+  };
+}


### PR DESCRIPTION
## Summary
- add new `plasma` module for NixOS
- document Plasma module in README
- keep module list alphabetical

## Testing
- `bash scripts/setup_testing_tools.sh` *(failed: installing Nix as root not supported)*
- `nix fmt` *(failed: `nix` command not found)*
- `nix flake check` *(failed: `nix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868989f587c8328a6be8bd63d139be8