### PR TITLE
Integrate omarchy-nix for bravo host

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,11 @@
       url = "github:solrey3/dotfiles";
     };
     zen-browser.url = "github:MarceColl/zen-browser-flake";
+    omarchy-nix = {
+      url = "github:henrysipp/omarchy-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
+    };
   };
 
   # The `outputs` function will return all the build results of the flake.
@@ -62,6 +67,7 @@
     disko,
     dotfiles,
     zen-browser,
+    omarchy-nix,
     ...
   }: let
     # Load local user configuration
@@ -112,12 +118,10 @@
         modules =
           [
             ./hosts/bravo/configuration.nix
-            stylix.nixosModules.stylix
-            ./modules/stylix.nix
+            omarchy-nix.nixosModules.default
           ]
           ++ mkHome home-manager.nixosModules.home-manager [
-            ./modules/home/linux-desktop.nix
-            ./modules/home/linux-apps-x86_64.nix
+            omarchy-nix.homeManagerModules.default
           ];
       };
 

--- a/hosts/bravo/configuration.nix
+++ b/hosts/bravo/configuration.nix
@@ -12,11 +12,7 @@
       ./../../modules/nixos/nvidia-stable.nix
       # ./../../modules/nixos/plasma.nix
       # ./../../modules/nixos/xfce4.nix
-      ./../../modules/nixos/hyprland.nix
-      ./../../modules/nixos/pipewire.nix
-      ./../../modules/nixos/bluetooth.nix
       ./../../modules/nixos/avahi.nix
-      ./../../modules/nixos/docker.nix
       ./../../modules/nixos/jellyfin.nix
       ./../../modules/nixos/navidrome.nix
       ./../../modules/nixos/ollama.nix
@@ -29,6 +25,12 @@
 
   networking.hostName = "bravo"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
+
+  omarchy = {
+    full_name = "Buddha Christ";
+    email_address = "budchris@solrey3.com";
+    theme = "tokyo-night";
+  };
 
   # Configure network proxy if necessary
   # networking.proxy.default = "http://user:password@proxy:port/";


### PR DESCRIPTION
## Summary
- add `omarchy-nix` flake input
- apply Omarchy NixOS and Home Manager modules to `bravo`
- configure Omarchy user details and theme
- remove conflicting Stylix and service modules from `bravo`

## Testing
- ⚠️ `./scripts/setup_testing_tools.sh` *(failed: the group 'nixbld' specified in 'build-users-group' does not exist)*
- ⚠️ `nix fmt` *(failed: command not found)*
- ⚠️ `nix flake check` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aba6a3c6fc832888973d0cd7006d55