### PR TITLE
Define home state version for bravo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,13 @@
             omarchy-nix.nixosModules.default
           ]
           ++ mkHome home-manager.nixosModules.home-manager [
+            {
+              home = {
+                username = username;
+                homeDirectory = "/home/${username}";
+                stateVersion = "24.11";
+              };
+            }
             omarchy-nix.homeManagerModules.default
           ];
       };


### PR DESCRIPTION
## Summary
- specify Home Manager state version and user directory for bravo

## Testing
- `nix fmt` *(fails: command not found)*
- `nix flake check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abb07a4b94832885d931437e3b0b44