### PR TITLE
Add linux-desktop home module for bravo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,7 @@
                 stateVersion = "24.11";
               };
             }
+            ./modules/home/linux-desktop.nix
             omarchy-nix.homeManagerModules.default
           ];
       };


### PR DESCRIPTION
## Summary
- import `modules/home/linux-desktop.nix` into Bravo's Home Manager configuration

## Testing
- ⚠️ `scripts/setup_testing_tools.sh` (failed: build users group 'nixbld' has no members)
- ⚠️ `nix fmt` (command not found)
- ⚠️ `nix flake check` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68abbb5c8ff08328ac54fb371e790d28