### PR TITLE
Allow overriding Waybar configuration defaults

### DIFF
--- a/modules/home/waybar.nix
+++ b/modules/home/waybar.nix
@@ -2,7 +2,7 @@
 {
   programs.waybar = {
     enable = true;
-    settings = {
+    settings = lib.mkDefault {
       mainBar = {
         layer = "top";
         position = "top";
@@ -222,7 +222,7 @@
       };
     };
 
-    style = ''
+    style = lib.mkDefault ''
       * {
           border: none;
           border-radius: 0;


### PR DESCRIPTION
## Summary
- mark the Home Manager Waybar settings and style as defaults so other modules can override them without conflicts

## Testing
- nix fmt *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3431a0b1c8328aed2fdda7a4e8d7f